### PR TITLE
[fix] General - Fix PMD rules & refactor 

### DIFF
--- a/force-app/main/default/classes/sfpegForceDML_CTL.cls
+++ b/force-app/main/default/classes/sfpegForceDML_CTL.cls
@@ -5,21 +5,21 @@
 *              for simple insert / update DML operations.
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2020 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,113 +28,104 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 ***/
-
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegForceDML_CTL {
 
-/***
-* @description	Invocable enabled method to force the execution of a DML, bypassing possible
-*               'warn' duplicate rules.
-* @param		operations		List of DmlRequests to process (each request containing a DML
-*                               operation type (insert/update) and a record to process.
-* @return		List<SObject>	List of records processed by the DML operation (with ID set
-*                               for newly created records).
-* @exception   	dmlExceptions in case of processing issue. An empty list is returned in case of
-*               duplicate search issue (typically no matching rule defined on object).
-***/    
-        
-    @InvocableMethod(label='Execute DML' description='Execute a DML while bypassing duplicate rules.' category='SF PEG')
-    public static List<SObject> executeDML(List<DmlRequest> operations) {
-        System.debug('executeDML: START');
-        System.debug('executeDML: operations received ' + operations);
-        if ((operations == null) || (operations.size() == 0)) {
+	/***
+	* @description	Invocable enabled method to force the execution of a DML, bypassing possible
+	*               'warn' duplicate rules.
+	* @param		operations		List of DmlRequests to process (each request containing a DML
+	*                               operation type (insert/update) and a record to process.
+	* @return		List<SObject>	List of records processed by the DML operation (with ID set
+	*                               for newly created records).
+	* @exception   	dmlExceptions in case of processing issue. An empty list is returned in case of
+	*               duplicate search issue (typically no matching rule defined on object).
+	***/
+	@InvocableMethod(label='Execute DML' description='Execute a DML while bypassing duplicate rules.' category='SF PEG')
+	public static List<SObject> executeDML(List<DmlRequest> operations) {
+		System.debug('executeDML: START');
+		System.debug('executeDML: operations received ' + operations);
+		if ((operations == null) || (operations.size() == 0)) {
 			System.debug('executeDML: END KO / missing input operations');
-            throw new dmlException('Missing input operations');
-        }
+			throw new dmlException('Missing input operations');
+		}
 
-        // Preparing the list of records per DML operation
-        List<SObject> recordList = new List<SObject>();
-        // map of records to process per DML operation
-        Map<String,List<SObject>> operationMap = new Map<String,List<SObject>>();
-        // map of indexes in the DML list per original operation index
-        //Map<Integer,Integer> recordMap = new Map<Integer,Integer>();
-        Integer index = 0;
-        for (DmlRequest opeIter : operations) {
-            System.debug('executeDML: processing operation ' + opeIter);
-            System.debug('executeDML: corresponding index  ' + index);
+		// Preparing the list of records per DML operation
+		List<SObject> recordList = new List<SObject>();
+		// map of records to process per DML operation
+		Map<String,List<SObject>> operationMap = new Map<String,List<SObject>>();
+		// map of indexes in the DML list per original operation index
+		Integer index = 0;
+		for (DmlRequest opeIter : operations) {
+			System.debug('executeDML: processing operation ' + opeIter);
+			System.debug('executeDML: corresponding index  ' + index);
 
-            List<SObject> opeList = operationMap.get(opeIter.operation);
-            if (opeList == null) {
-                System.debug('executeDML: initializing sobject list for ' + opeIter.operation);
-                opeList = new List<SObject>();
-                operationMap.put(opeIter.operation, opeList);
-            }
+			List<SObject> opeList = operationMap.get(opeIter.operation);
+			if (opeList == null) {
+				System.debug('executeDML: initializing sobject list for ' + opeIter.operation);
+				opeList = new List<SObject>();
+				operationMap.put(opeIter.operation, opeList);
+			}
 
-            opeList.add(opeIter.record);
-            recordList.add(opeIter.record);
-            //recordMap.put(index,opeList.size());
-            index++;
-        }
-        System.debug('executeDML: operationMap init ' + operationMap);
-        //System.debug('executeDML: recordMap init ' + recordMap);
-        System.debug('executeDML: recordList init ' + recordList);
+			opeList.add(opeIter.record);
+			recordList.add(opeIter.record);
+			index++;
+		}
+		System.debug('executeDML: operationMap init ' + operationMap);
+		System.debug('executeDML: recordList init ' + recordList);
 
 
-        // Executing the required DML operations
-        Database.DMLOptions dmlHeader = new Database.DMLOptions(); 
-        dmlHeader.DuplicateRuleHeader.allowSave = true;
-        dmlHeader.DuplicateRuleHeader.runAsCurrentUser = true;
-        System.debug('executeDML: DML header set to bypass alert duplicate rules ' + dmlHeader);
+		// Executing the required DML operations
+		Database.DMLOptions dmlHeader = new Database.DMLOptions();
+		dmlHeader.DuplicateRuleHeader.allowSave = true;
+		dmlHeader.DuplicateRuleHeader.runAsCurrentUser = true;
+		System.debug('executeDML: DML header set to bypass alert duplicate rules ' + dmlHeader);
 
-        // map of records updates/inserted per DML operation
-        //Map<String,Database.SaveResult> resultMap = new Map<String,Database.SaveResult>();
-        for (String dmlIter : operationMap.keySet()) {
-            System.debug('executeDML: processing DML ' + dmlIter);
-            List<SObject> dmlRecords = operationMap.get(dmlIter);
-            System.debug('executeDML: records to processs fetched ' + dmlRecords);
+		// map of records updates/inserted per DML operation
+		for (String dmlIter : operationMap.keySet()) {
+			System.debug('executeDML: processing DML ' + dmlIter);
+			List<SObject> dmlRecords = operationMap.get(dmlIter);
+			System.debug('executeDML: records to processs fetched ' + dmlRecords);
 
-            List<Database.SaveResult> saveResults;
-            switch on  dmlIter {
-                when 'insert' {
-                    System.debug('executeDML: processing insert DML');
-                    saveResults = Database.insert(dmlRecords, dmlHeader);
-                }
-                when 'update' {
-                    System.debug('executeDML: processing update DML');
-                    saveResults = Database.update(dmlRecords, dmlHeader);
-                }
-                when else {
-                    System.debug('executeDML: unsupported DML ' + dmlIter);
-                    throw new dmlException('Unsupported DML operation: ' + dmlIter); 
-                }
-            }
-            System.debug('executeDML: DML operation executed ' + saveResults);
-            for (Database.SaveResult resIter : saveResults) {
-                if (resIter.isSuccess()) {
-                    System.debug('executeDML: DML operation OK ' + resIter);
-                }
-                else {
-                    System.debug('executeDML: DML operation KO ' + resIter);
-                    throw new dmlException((resIter.getErrors())[0].getMessage());
-                }
-            }
-            //System.debug('executeDML: records list ' + dmlRecords);
-            //System.debug('executeDML: 1st records ID ' + saveResults[0].getId());
-            //resultMap.put(dmlIter,saveResults);
-        }
-        //System.debug('executeDML: resultMap init ' + resultMap);
+			List<Database.SaveResult> saveResults;
+			switch on  dmlIter {
+				when 'insert' {
+					System.debug('executeDML: processing insert DML');
+					saveResults = Database.insert(dmlRecords, dmlHeader);
+				}
+				when 'update' {
+					System.debug('executeDML: processing update DML');
+					saveResults = Database.update(dmlRecords, dmlHeader);
+				}
+				when else {
+					System.debug('executeDML: unsupported DML ' + dmlIter);
+					throw new dmlException('Unsupported DML operation: ' + dmlIter);
+				}
+			}
+			System.debug('executeDML: DML operation executed ' + saveResults);
+			for (Database.SaveResult resIter : saveResults) {
+				if (resIter.isSuccess()) {
+					System.debug('executeDML: DML operation OK ' + resIter);
+				}
+				else {
+					System.debug('executeDML: DML operation KO ' + resIter);
+					throw new dmlException((resIter.getErrors())[0].getMessage());
+				}
+			}
+		}
 
-        System.debug('executeDML: END with ' + recordList);
-        return recordList;
-    }
+		System.debug('executeDML: END with ' + recordList);
+		return recordList;
+	}
 
-    /***
-    * @description	Subclass required to pass input parameters into the 'getData' invocable action
-    *               (especially to provide the fieldset name).
-    ***/
-    public class DmlRequest {
-        @InvocableVariable(label='Record' description='Record to process' required=true)
-        public SObject record;
-        @InvocableVariable(label='Operation' description='DML Operation to execute (insert, update)' required=true)
-        public String operation;
-    }
-}   
+	/***
+	* @description	Subclass required to pass input parameters into the 'getData' invocable action
+	*               (especially to provide the fieldset name).
+	***/
+	public class DmlRequest {
+		@InvocableVariable(label='Record' description='Record to process' required=true)
+		public SObject record;
+		@InvocableVariable(label='Operation' description='DML Operation to execute (insert, update)' required=true)
+		public String operation;
+	}
+}

--- a/force-app/main/default/classes/sfpegForceDML_CTL_TST.cls
+++ b/force-app/main/default/classes/sfpegForceDML_CTL_TST.cls
@@ -5,21 +5,21 @@
 * @see         sfpegForceDML_CTL
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2020 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,92 +30,90 @@
 ***/
 
 @isTest
-public class  sfpegForceDML_CTL_TST {
-    
-/***
-* @description Initializes the test context.
-***/
-    @testSetup
-    static void testSetup() {
-        System.debug('testSetup: START');
+public class sfpegForceDML_CTL_TST {
 
-        System.debug('testSetup: END');
-    }
+	/***
+	* @description Initializes the test context.
+	***/
+	@testSetup
+	static void testSetup() {
+		System.debug('testSetup: START');
 
+		System.debug('testSetup: END');
+	}
 
-/***
-* @description Tests the "executeDML" method.
-***/
-    
-    static TestMethod void testExecuteDML() {
-        System.debug('testExecuteDMLs: START'); 
-        Test.startTest();
-        
-        Task newTask = new Task(Subject = 'Test', Status = 'En cours', ActivityDate = date.newinstance(2021,01,01));
-        Task newTask2 = new Task(Subject = 'Test2', Status = 'En cours', ActivityDate = date.newinstance(2021,01,02));
-        sfpegForceDML_CTL.DmlRequest newRequest = new sfpegForceDML_CTL.DmlRequest();
-        newRequest.record = newTask;
-        newRequest.operation = 'insert';
-        list<sfpegForceDML_CTL.DmlRequest> requestList = new list<sfpegForceDML_CTL.DmlRequest>();
-        requestList.add(newRequest);
-        System.debug('testExecuteDMLs: data ready'); 
-         
-        List<SObject> results;
-        try {
-	        results = sfpegForceDML_CTL.executeDML(null);
-            System.debug('testExecuteDMLs: null request fetched' + results); 
-            System.assert(false);
-        }
-        catch (Exception e) {
-            System.debug('testExecuteDMLs: null request error' + e.getMessage());
-            System.assert(true);          
-        }
-         
-        try {
-	        results = sfpegForceDML_CTL.executeDML(requestList);
-            System.debug('testExecuteDMLs: insert done ' + results); 
-            System.assertEquals(results.size(),1);
-            System.assertNotEquals(results[0].Id,null);
-        }
-        catch (Exception e) {
-            System.debug('testExecuteDMLs: duplicates error' + e.getMessage());  
-            System.assert(false);           
-        }
+	/***
+	* @description Tests the "executeDML" method.
+	***/
+	@isTest
+    static void testExecuteDML() {
+		System.debug('testExecuteDMLs: START');
+		Test.startTest();
 
-        newTask.Id = results[0].Id;
-        newTask.Subject = 'Test Update';
-        newRequest.operation = 'update';
-        sfpegForceDML_CTL.DmlRequest newRequest2 = new sfpegForceDML_CTL.DmlRequest();
-        newRequest2.record = newTask2;
-        newRequest2.operation = 'insert';
-        requestList.add(newRequest2);
-        System.debug('testExecuteDMLs: test data updated ');
-        
-        try {
-	        results = sfpegForceDML_CTL.executeDML(requestList);
-            System.debug('testExecuteDMLs: combined DML done ' + results); 
-            System.assertEquals(results.size(),2);
-        }
-        catch (Exception e) {
-            System.debug('testExecuteDMLs: combined DML error' + e.getMessage());
-            System.assert(false);          
-        }
+		Task newTask = new Task(Subject = 'Test', Status = 'En cours', ActivityDate = date.newinstance(2021,01,01));
+		Task newTask2 = new Task(Subject = 'Test2', Status = 'En cours', ActivityDate = date.newinstance(2021,01,02));
+		sfpegForceDML_CTL.DmlRequest newRequest = new sfpegForceDML_CTL.DmlRequest();
+		newRequest.record = newTask;
+		newRequest.operation = 'insert';
+		list<sfpegForceDML_CTL.DmlRequest> requestList = new list<sfpegForceDML_CTL.DmlRequest>();
+		requestList.add(newRequest);
+		System.debug('testExecuteDMLs: data ready');
 
-        newTask.Subject = 'Test Failure';
-        newRequest.operation = 'dummy';
-        try {
-	        results = sfpegForceDML_CTL.executeDML(requestList);
-            System.debug('testExecuteDMLs: dummy DML done ' + results); 
-            System.assert(false);
-        }
-        catch (Exception e) {
-            System.debug('testExecuteDMLs: dummy DML error' + e.getMessage()); 
-            System.assert(true);            
-        }
-		
+		List<SObject> results;
+		try {
+			results = sfpegForceDML_CTL.executeDML(null);
+			System.debug('testExecuteDMLs: null request fetched' + results);
+			System.assert(false);
+		}
+		catch (Exception e) {
+			System.debug('testExecuteDMLs: null request error' + e.getMessage());
+			System.assert(true);
+		}
+
+		try {
+			results = sfpegForceDML_CTL.executeDML(requestList);
+			System.debug('testExecuteDMLs: insert done ' + results);
+			System.assertEquals(results.size(),1);
+			System.assertNotEquals(results[0].Id,null);
+		}
+		catch (Exception e) {
+			System.debug('testExecuteDMLs: duplicates error' + e.getMessage());
+			System.assert(false);
+		}
+
+		newTask.Id = results[0].Id;
+		newTask.Subject = 'Test Update';
+		newRequest.operation = 'update';
+		sfpegForceDML_CTL.DmlRequest newRequest2 = new sfpegForceDML_CTL.DmlRequest();
+		newRequest2.record = newTask2;
+		newRequest2.operation = 'insert';
+		requestList.add(newRequest2);
+		System.debug('testExecuteDMLs: test data updated ');
+
+		try {
+			results = sfpegForceDML_CTL.executeDML(requestList);
+			System.debug('testExecuteDMLs: combined DML done ' + results);
+			System.assertEquals(results.size(),2);
+		}
+		catch (Exception e) {
+			System.debug('testExecuteDMLs: combined DML error' + e.getMessage());
+			System.assert(false);
+		}
+
+		newTask.Subject = 'Test Failure';
+		newRequest.operation = 'dummy';
+		try {
+			results = sfpegForceDML_CTL.executeDML(requestList);
+			System.debug('testExecuteDMLs: dummy DML done ' + results);
+			System.assert(false);
+		}
+		catch (Exception e) {
+			System.debug('testExecuteDMLs: dummy DML error' + e.getMessage());
+			System.assert(true);
+		}
+
 		Test.stopTest();
-        
-		System.debug('testGetDuplicates: END');
-    }
 
+		System.debug('testGetDuplicates: END');
+	}
 }

--- a/force-app/main/default/classes/sfpegForceDML_CTL_TST.cls
+++ b/force-app/main/default/classes/sfpegForceDML_CTL_TST.cls
@@ -30,6 +30,7 @@
 ***/
 
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions')
 public class sfpegForceDML_CTL_TST {
 
 	/***

--- a/force-app/main/default/classes/sfpegGetDuplicates_CTL.cls
+++ b/force-app/main/default/classes/sfpegGetDuplicates_CTL.cls
@@ -27,7 +27,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 ***/
-
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegGetDuplicates_CTL {
 
 	/***

--- a/force-app/main/default/classes/sfpegGetDuplicates_CTL.cls
+++ b/force-app/main/default/classes/sfpegGetDuplicates_CTL.cls
@@ -4,21 +4,21 @@
 * @description Flow controller class to check duplicates of a new record from a Flow.
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2020 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,39 +30,37 @@
 
 public with sharing class sfpegGetDuplicates_CTL {
 
-/***
-* @description	Invocable method to easily fetch duplicates of a record, while returning
-*               their compact layout fields.
-* @param		newRecords		List of records for which duplicates should be searched (should
-*                               be of same type and less than 50)		
-* @return		List<MatchResults>		List of duplicates for each record (of same sobject type)
-*                                       with set of fields corresponding to their compact layout,
-*                                       and with the list of applicable duplicate rule warning
-*                                       messages (concatenated with <br/> tags for easy display).
-* @exception   	dmlExceptions in case of processing issue. An empty list is returned in case of
-*               duplicate search issue (typically no matching rule defined on object).
-***/    
-	
+	/***
+	* @description	Invocable method to easily fetch duplicates of a record, while returning
+	*               their compact layout fields.
+	* @param		newRecords		List of records for which duplicates should be searched (should
+	*                               be of same type and less than 50)
+	* @return		List<MatchResults>		List of duplicates for each record (of same sobject type)
+	*                                       with set of fields corresponding to their compact layout,
+	*                                       and with the list of applicable duplicate rule warning
+	*                                       messages (concatenated with <br/> tags for easy display).
+	* @exception   	dmlExceptions in case of processing issue. An empty list is returned in case of
+	*               duplicate search issue (typically no matching rule defined on object).
+	***/
 	@InvocableMethod(label='Get Duplicates' description='Get duplicates of a record to create.' category='SF PEG')
 	public static List<MatchResults> getDuplicates(List<SObject> newRecords) {
 		System.debug('getDuplicates: START');
-		//System.debug('getDuplicates: newRecords received ' + newRecords);
-        
-        if ((newRecords == null) || (newRecords.size() == 0)) {
+
+		if ((newRecords == null) || (newRecords.size() == 0)) {
 			System.debug('getDuplicates: END KO / missing input records');
-            throw new dmlException('Missing input records');
-        }
-        if (newRecords.size() > 50) {
+			throw new dmlException('Missing input records');
+		}
+		if (newRecords.size() > 50) {
 			System.debug('getDuplicates: END KO / too many records 50 < ' + newRecords.size());
-            throw new dmlException('Too many records');
-        }
-		  
+			throw new dmlException('Too many records');
+		}
+
 		List<MatchResults> resultList = new List<MatchResults>();
-        try {
+		try {
 			List<Datacloud.FindDuplicatesResult> duplicates = Datacloud.FindDuplicates.findDuplicates(newRecords);
 			System.debug('getDuplicates: duplicates searched ' + duplicates);
-            Integer index = 0;
-            for (Datacloud.FindDuplicatesResult findDupeResult : duplicates) {
+			Integer index = 0;
+			for (Datacloud.FindDuplicatesResult findDupeResult : duplicates) {
 				System.debug('getDuplicates: processing index ' + index);
 				SObject newRecord = newRecords.get(index);
 				System.debug('getDuplicates: new record ' + newRecord);
@@ -71,19 +69,18 @@ public with sharing class sfpegGetDuplicates_CTL {
 				Set<ID> recordIdMatches = new Set<ID>();
 				List<SObject> recordMatches = new List<SObject>();
 				List<String> warningMsgs = new List<String>();
-				Boolean allowSave = true;
   				for (Datacloud.DuplicateResult dupeResult : findDupeResult.getDuplicateResults()) {
 					System.debug('getDuplicates: dupeResult fetched ' + dupeResult);
-					
+
 					if (dupeResult.getMatchResults().size() > 0) {
 						System.debug('getDuplicates: #duplicates to process ' + dupeResult.getMatchResults().size());
 
 						System.debug('getDuplicates: registering message ' + dupeResult.getErrorMessage());
 						warningMsgs.add(dupeResult.getErrorMessage());
-					
-    					for (Datacloud.MatchResult matchResult : dupeResult.getMatchResults()) {
+
+						for (Datacloud.MatchResult matchResult : dupeResult.getMatchResults()) {
 							System.debug('getDuplicates: matchResult fetched ' + matchResult);
-      						for (Datacloud.MatchRecord matchRecord : matchResult.getMatchRecords()) {
+	  						for (Datacloud.MatchRecord matchRecord : matchResult.getMatchRecords()) {
 								SObject matchSobject = matchRecord.getRecord();
 								System.debug('getDuplicates: Duplicate Record found ' + matchSobject);
 								if (recordIdMatches.contains(matchSobject.Id)) {
@@ -94,178 +91,41 @@ public with sharing class sfpegGetDuplicates_CTL {
 									recordMatches.add(matchSobject);
 									recordIdMatches.add(matchSobject.Id);
 								}
-                        	}
+							}
 						}
 					}
 					else {
 						System.debug('getDuplicates: no duplicates to process ');
 						System.debug('getDuplicates: message ignored ' + dupeResult.getErrorMessage());
 					}
-                }
+				}
 				System.debug('getDuplicates: recordMatches init ' + recordMatches);
 				MatchResults resultItem = new MatchResults();
-                resultItem.records = recordMatches;
+				resultItem.records = recordMatches;
 				resultItem.messages = String.join(warningMsgs,'<br/>');
 				System.debug('getDuplicates: resultItem init ' + resultItem);
 				resultList.add(resultItem);
-                index++;
-            }
-        }
-        catch (Exception e) {
-			System.debug('getDuplicates: duplicates search failed ' + e.getMessage()); 
-            return null;
-        }
+				index++;
+			}
+		}
+		catch (Exception e) {
+			System.debug('getDuplicates: duplicates search failed ' + e.getMessage());
+			return null;
+		}
 		System.debug('getDuplicates: duplicates found ' + resultList);
 
 		System.debug('getDuplicates: END OK');
-        return resultList;
+		return resultList;
 	}
 
-	
-/***
-* @description	Subclass required to pass output parameters into the 'getDuplicates' invocable action
-*               (especially to provide the "save allowed" boolean flag).
-***/
+	/***
+	* @description	Subclass required to pass output parameters into the 'getDuplicates' invocable action
+	*               (especially to provide the "save allowed" boolean flag).
+	***/
 	public class MatchResults {
 		@InvocableVariable(label='Matching Records' description='Matching Records determined by rules' required=true)
 		public List<SObject> records;
 		@InvocableVariable(label='Messages' description='Warning messages of the duplicate rules triggered' required=true)
 		public String messages;
-	}
-
-/***
-* @description	Fake class to enhance test coverage and avoid matching rules deployment issues
-***/
-	public class DummyTestClass {
-		public void dummyMethod() {
-			Integer index = 0;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;
-			index++;			
-		}
 	}
 }

--- a/force-app/main/default/classes/sfpegGetDuplicates_CTL_TST.cls
+++ b/force-app/main/default/classes/sfpegGetDuplicates_CTL_TST.cls
@@ -51,10 +51,10 @@ public class sfpegGetDuplicates_CTL_TST {
 	}
 
 	/***
-	* @description Tests the "getDuplicates" method.
+	* @description Tests he "getDuplicates" method.
 	***/
 	@isTest
-    static void testGetDuplicates() {
+	static void testGetDuplicates() {
 		System.debug('testGetDuplicates: START');
 		Test.startTest();
 
@@ -108,14 +108,5 @@ public class sfpegGetDuplicates_CTL_TST {
 		Test.stopTest();
 
 		System.debug('testGetDuplicates: END');
-	}
-
-	@isTest
-	static void testDummy() {
-		System.debug('testDummy: START');
-		Test.startTest();
-		(new sfpegGetDuplicates_CTL.DummyTestClass()).dummyMethod();
-		Test.stopTest();
-		System.debug('testDummy: END');
 	}
 }

--- a/force-app/main/default/classes/sfpegGetDuplicates_CTL_TST.cls
+++ b/force-app/main/default/classes/sfpegGetDuplicates_CTL_TST.cls
@@ -5,21 +5,21 @@
 * @see         sfpegGetDuplicates_CTL
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2020 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,94 +30,92 @@
 ***/
 
 @isTest
-public class  sfpegGetDuplicates_CTL_TST {
-    
-/***
-* @description Initializes the test context.
-***/
-    @testSetup
-    static void testSetup() {
-        System.debug('testSetup: START');
+public class sfpegGetDuplicates_CTL_TST {
 
-        List<sfpegTest__c> newTests  = new List<sfpegTest__c>();
-        sfpegTest__c newTest1 = new sfpegTest__c(Name = 'Test1');
-        newTests.add(newTest1);
-        sfpegTest__c newTest2 = new sfpegTest__c(Name = 'Test2',Data__c = 'Data2');
-        newTests.add(newTest2);
+	/***
+	* @description Initializes the test context.
+	***/
+	@testSetup
+	static void testSetup() {
+		System.debug('testSetup: START');
 
-        insert newTests;
+		List<sfpegTest__c> newTests  = new List<sfpegTest__c>();
+		sfpegTest__c newTest1 = new sfpegTest__c(Name = 'Test1');
+		newTests.add(newTest1);
+		sfpegTest__c newTest2 = new sfpegTest__c(Name = 'Test2', Data__c = 'Data2');
+		newTests.add(newTest2);
 
-        System.debug('testSetup: END');
-    }
+		insert newTests;
 
+		System.debug('testSetup: END');
+	}
 
-/***
-* @description Tests the "getDuplicates" method.
-***/
-    
-    static TestMethod void testGetDuplicates() {
-        System.debug('testGetDuplicates: START'); 
-        Test.startTest();
-        
-        //List<List<SObject>> results;
-        List<sfpegGetDuplicates_CTL.MatchResults> results;
-        try {
-	        results = sfpegGetDuplicates_CTL.getDuplicates(null);
-            System.debug('testGetDuplicates: null duplicates fetched' + results); 
-            system.assert(false);
-        }
-        catch (Exception e) {
-            System.debug('testGetDuplicates: null duplicates error' + e.getMessage());  
-            system.assert(true);           
-        }
-        
-        List<SObject> newTests  = new List<SObject>();
-        sfpegTest__c newTest1 = new sfpegTest__c(Name = 'Test1');
-        newTests.add(newTest1);
-        sfpegTest__c newTest11 = new sfpegTest__c(Name = 'Test1', Data__c = 'Data1');
-        newTests.add(newTest11);
-        sfpegTest__c newTest2 = new sfpegTest__c(Name = 'Test2');        
-        newTests.add(newTest2);
-        sfpegTest__c newTest22 = new sfpegTest__c(Name = 'Test2', Data__c = 'Data2');
-        newTests.add(newTest22);
-        System.debug('testGetDuplicates: data ready ' + newTests); 
+	/***
+	* @description Tests the "getDuplicates" method.
+	***/
+	@isTest
+    static void testGetDuplicates() {
+		System.debug('testGetDuplicates: START');
+		Test.startTest();
 
-        try {
-	        results = sfpegGetDuplicates_CTL.getDuplicates(newTests);
-            System.debug('testGetDuplicates: duplicates fetched' + results); 
-            system.assert(true);
-        }
-        catch (Exception e) {
-            System.debug('testGetDuplicates: duplicates error' + e.getMessage());  
-            system.assert(false);           
-        }
+		List<sfpegGetDuplicates_CTL.MatchResults> results;
+		try {
+			results = sfpegGetDuplicates_CTL.getDuplicates(null);
+			System.debug('testGetDuplicates: null duplicates fetched' + results);
+			System.assert(false);
+		}
+		catch (Exception e) {
+			System.debug('testGetDuplicates: null duplicates error' + e.getMessage());
+			System.assert(true);
+		}
+
+		List<SObject> newTests  = new List<SObject>();
+		sfpegTest__c newTest1 = new sfpegTest__c(Name = 'Test1');
+		newTests.add(newTest1);
+		sfpegTest__c newTest11 = new sfpegTest__c(Name = 'Test1', Data__c = 'Data1');
+		newTests.add(newTest11);
+		sfpegTest__c newTest2 = new sfpegTest__c(Name = 'Test2');
+		newTests.add(newTest2);
+		sfpegTest__c newTest22 = new sfpegTest__c(Name = 'Test2', Data__c = 'Data2');
+		newTests.add(newTest22);
+		System.debug('testGetDuplicates: data ready ' + newTests);
+
+		try {
+			results = sfpegGetDuplicates_CTL.getDuplicates(newTests);
+			System.debug('testGetDuplicates: duplicates fetched' + results);
+			System.assert(true);
+		}
+		catch (Exception e) {
+			System.debug('testGetDuplicates: duplicates error' + e.getMessage());
+			System.assert(false);
+		}
 
 		Integer iter = 0;
-        while (iter < 50) {
-            newTests.add(new sfpegTest__c(Name = 'Test' + iter));
-            iter++;
-        }
-        try {
-	        results = sfpegGetDuplicates_CTL.getDuplicates(newTests);
-            System.debug('testGetDuplicates: > 50 duplicates fetched' + results); 
-            system.assert(false);
-        }
-        catch (Exception e) {
-            System.debug('testGetDuplicates: > 50 duplicates error' + e.getMessage()); 
-            system.assert(true);            
-        }
+		while (iter < 50) {
+			newTests.add(new sfpegTest__c(Name = 'Test' + iter));
+			iter++;
+		}
+		try {
+			results = sfpegGetDuplicates_CTL.getDuplicates(newTests);
+			System.debug('testGetDuplicates: > 50 duplicates fetched' + results);
+			System.assert(false);
+		}
+		catch (Exception e) {
+			System.debug('testGetDuplicates: > 50 duplicates error' + e.getMessage());
+			System.assert(true);
+		}
 
-        
 		Test.stopTest();
-        
-		System.debug('testGetDuplicates: END');
-    }
 
-    static TestMethod void testDummy() {
-        System.debug('testDummy: START'); 
-        Test.startTest();
-        (new sfpegGetDuplicates_CTL.DummyTestClass()).dummyMethod();
-        Test.stopTest();
+		System.debug('testGetDuplicates: END');
+	}
+
+	@isTest
+	static void testDummy() {
+		System.debug('testDummy: START');
+		Test.startTest();
+		(new sfpegGetDuplicates_CTL.DummyTestClass()).dummyMethod();
+		Test.stopTest();
 		System.debug('testDummy: END');
-    }
+	}
 }

--- a/force-app/main/default/classes/sfpegGetDuplicates_CTL_TST.cls
+++ b/force-app/main/default/classes/sfpegGetDuplicates_CTL_TST.cls
@@ -30,6 +30,7 @@
 ***/
 
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions')
 public class sfpegGetDuplicates_CTL_TST {
 
 	/***

--- a/force-app/main/default/classes/sfpegGetFieldSet_CTL.cls
+++ b/force-app/main/default/classes/sfpegGetFieldSet_CTL.cls
@@ -4,21 +4,21 @@
 * @date        Oct. 2020
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2020 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,97 +27,96 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 ***/
-
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegGetFieldSet_CTL {
 
-/***
-* @description Simple method to fetch the list of fields allowed for the user included in
-*              a configured field set.
-* @param       fieldSet             Dev Name of the Field Set 
-* @return      Map<String,Object>   Map containing 2 entries:
-*                                   'label' with the label of the field set,
-*                                   'fields' with the label, name and type of each accessible field
-* @exception   none really specific.
-***/
-@AuraEnabled(cacheable=true)
-public static Map<String,Object> getFieldSetDesc(final String name) {
-    System.debug('getFieldSetDesc: START with field set name ' + name);
+	/***
+	* @description Simple method to fetch the list of fields allowed for the user included in
+	*              a configured field set.
+	* @param       fieldSet             Dev Name of the Field Set
+	* @return      Map<String,Object>   Map containing 2 entries:
+	*                                   'label' with the label of the field set,
+	*                                   'fields' with the label, name and type of each accessible field
+	* @exception   none really specific.
+	***/
+	@AuraEnabled(cacheable=true)
+	public static Map<String,Object> getFieldSetDesc(final String name) {
+		System.debug('getFieldSetDesc: START with field set name ' + name);
 
-    String[] fsParts = name.split('\\.');
-    System.debug('getFieldSetDesc: fsParts extracted ' + fsParts);
-    if (fsParts.size()<> 2) throw new AuraHandledException(
-        'Bad field set name format for ' + name + '\n Should be "object.fsName".');
+		String[] fsParts = name.split('\\.');
+		System.debug('getFieldSetDesc: fsParts extracted ' + fsParts);
+		if (fsParts.size()<> 2) throw new AuraHandledException(
+			'Bad field set name format for ' + name + '\n Should be "object.fsName".');
 
-    String objName = fsParts[0];
-    System.debug('getFieldSetDesc: objName extracted ' + objName);
-    String fsName  = fsParts[1];
-    System.debug('getFieldSetDesc: fsName extracted ' + fsName);
+		String objName = fsParts[0];
+		System.debug('getFieldSetDesc: objName extracted ' + objName);
+		String fsName  = fsParts[1];
+		System.debug('getFieldSetDesc: fsName extracted ' + fsName);
 
-    Schema.SObjectType objDesc = Schema.getGlobalDescribe().get(objName);
-    if (objDesc == null) throw new AuraHandledException(
-        'Unknown Object Name for field set ' + name + ' !');
-    System.debug('getFieldSetDesc: object descriptor found ');
+		Schema.SObjectType objDesc = Schema.getGlobalDescribe().get(objName);
+		if (objDesc == null) throw new AuraHandledException(
+			'Unknown Object Name for field set ' + name + ' !');
+		System.debug('getFieldSetDesc: object descriptor found ');
 
-    Schema.FieldSet fsDesc = objDesc.getDescribe().fieldSets.getMap().get(fsName);
-    if (fsDesc == null) throw new AuraHandledException(
-        'Unknown Field Set Name for field set ' + name + ' !');
-    System.debug('getFieldSet: field set descriptor found ');
+		Schema.FieldSet fsDesc = objDesc.getDescribe().fieldSets.getMap().get(fsName);
+		if (fsDesc == null) throw new AuraHandledException(
+			'Unknown Field Set Name for field set ' + name + ' !');
+		System.debug('getFieldSet: field set descriptor found ');
 
-    Map<String,Object> descResult = new Map<String,Object>();
-    descResult.put('label',fsDesc.getLabel());
-    System.debug('getFieldSet: field set Label set ' + fsDesc.getLabel());
+		Map<String,Object> descResult = new Map<String,Object>();
+		descResult.put('label',fsDesc.getLabel());
+		System.debug('getFieldSet: field set Label set ' + fsDesc.getLabel());
 
-    List<Map<String,Object>> fieldDescs = new List<Map<String,Object>>();
-    descResult.put('fields',fieldDescs);
-    for (Schema.FieldSetMember fieldIter : fsDesc.getFields()) {
-        System.debug('getFieldSet: processing field ' + fieldIter.getSObjectField());
+		List<Map<String,Object>> fieldDescs = new List<Map<String,Object>>();
+		descResult.put('fields',fieldDescs);
+		for (Schema.FieldSetMember fieldIter : fsDesc.getFields()) {
+			System.debug('getFieldSet: processing field ' + fieldIter.getSObjectField());
 
-        Schema.DescribeFieldResult fieldDesc = fieldIter.getSObjectField().getDescribe();
-        System.debug('getFieldSet: fieldDesc fetched ' + fieldDesc);
+			Schema.DescribeFieldResult fieldDesc = fieldIter.getSObjectField().getDescribe();
+			System.debug('getFieldSet: fieldDesc fetched ' + fieldDesc);
 
-        if (fieldDesc.isAccessible()) {
-            System.debug('getFieldSet: adding accessible field ' + fieldIter.getSObjectField());
-            Map<String,Object> fieldMap = new Map<String,Object> {
-                'label' => fieldDesc.getLabel(),
-                'name' => fieldDesc.getName(),
-                'type' => '' + fieldDesc.getType(),
-                'required' => fieldIter.getRequired()
-            };
-            fieldDescs.add(fieldMap);
-        }
-        else {
-            System.debug('getFieldSet: field not accessible ' + fieldIter.getSObjectField());
-        }
-    }
+			if (fieldDesc.isAccessible()) {
+				System.debug('getFieldSet: adding accessible field ' + fieldIter.getSObjectField());
+				Map<String,Object> fieldMap = new Map<String,Object> {
+					'label' => fieldDesc.getLabel(),
+					'name' => fieldDesc.getName(),
+					'type' => '' + fieldDesc.getType(),
+					'required' => fieldIter.getRequired()
+				};
+				fieldDescs.add(fieldMap);
+			}
+			else {
+				System.debug('getFieldSet: field not accessible ' + fieldIter.getSObjectField());
+			}
+		}
 
-    System.debug('getFieldSet: fieldDescs prepared ' + fieldDescs);
-    System.debug('getFieldSet: descResult finalised ' + descResult);
+		System.debug('getFieldSet: fieldDescs prepared ' + fieldDescs);
+		System.debug('getFieldSet: descResult finalised ' + descResult);
 
-    System.debug('getFieldSet: END for fieldDescs with size ' + fieldDescs.size());
-    return descResult;
-}
+		System.debug('getFieldSet: END for fieldDescs with size ' + fieldDescs.size());
+		return descResult;
+	}
 
-/***
-* @description Simple method to fetch the list of fields allowed for the user included in
-*              a list of configured field sets. This method iterates over the list by 
-*              calling the unitary getFieldSetDesc method and agregates the resuts.
-* @param       fieldSets            List of Field Set's Dev Names  
-* @return      Map<String,Object>   Map of maps containing the fieldSet description
-*                                   retrieved for each fieldset name.
-* @exception   None really specific.
-***/
-@AuraEnabled(cacheable=true)
-public static Map<String,Object> getFieldSetDescs(final list<String> names) {
-    System.debug('getFieldSetDescs: START with ' + names.size() + ' elements');
-    Map<String,Object> nameDescs = new Map<String,Object>();
+	/***
+	* @description Simple method to fetch the list of fields allowed for the user included in
+	*              a list of configured field sets. This method iterates over the list by
+	*              calling the unitary getFieldSetDesc method and agregates the resuts.
+	* @param       fieldSets            List of Field Set's Dev Names
+	* @return      Map<String,Object>   Map of maps containing the fieldSet description
+	*                                   retrieved for each fieldset name.
+	* @exception   None really specific.
+	***/
+	@AuraEnabled(cacheable=true)
+	public static Map<String,Object> getFieldSetDescs(final list<String> names) {
+		System.debug('getFieldSetDescs: START with ' + names.size() + ' elements');
+		Map<String,Object> nameDescs = new Map<String,Object>();
 
-    for (String iterName : names) {
-        System.debug('getFieldSetDescs: processing field set ' + iterName);
-        nameDescs.put(iterName, getFieldSetDesc(iterName));
-    }
+		for (String iterName : names) {
+			System.debug('getFieldSetDescs: processing field set ' + iterName);
+			nameDescs.put(iterName, getFieldSetDesc(iterName));
+		}
 
-    System.debug('getFieldSetDescs: END with nameDescs ' + nameDescs);
-    return nameDescs;
-}
-
+		System.debug('getFieldSetDescs: END with nameDescs ' + nameDescs);
+		return nameDescs;
+	}
 }

--- a/force-app/main/default/classes/sfpegGetFieldSet_CTL_TST.cls
+++ b/force-app/main/default/classes/sfpegGetFieldSet_CTL_TST.cls
@@ -30,6 +30,7 @@
 ***/
 
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegGetFieldSet_CTL_TST {
 
 	/***
@@ -64,7 +65,6 @@ public with sharing class sfpegGetFieldSet_CTL_TST {
 			List<String> nameList = new List<String>();
 			nameList.add(FieldSetName);
 			sfpegGetFieldSet_CTL.getFieldSetDescs(nameList);
-			//sfpegConfiguration_CTL.getFieldSetDesc('Task.SFPEG_TSTFS');
 			System.debug('testGetFieldSetDesc: no exception raised');
 			System.assert(true);
 		}
@@ -78,7 +78,6 @@ public with sharing class sfpegGetFieldSet_CTL_TST {
 			List<String> nameList = new List<String>();
 			nameList.add(FieldSetNameKO);
 			sfpegGetFieldSet_CTL.getFieldSetDescs(nameList);
-			//sfpegConfiguration_CTL.getFieldSetDesc('Task.SFPEG_TSTFS');
 			System.debug('testGetFieldSetDesc: no exception raised');
 			System.assert(false);
 		}

--- a/force-app/main/default/classes/sfpegGetFieldSet_CTL_TST.cls
+++ b/force-app/main/default/classes/sfpegGetFieldSet_CTL_TST.cls
@@ -5,21 +5,21 @@
 * @see         sfpegGetFieldSet_CTL
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2020 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,87 +32,86 @@
 @isTest
 public with sharing class sfpegGetFieldSet_CTL_TST {
 
+	/***
+	* @description Initializes the test context.
+	***/
+	@testSetup
+	static void testSetup() {
+		System.debug('testSetup: START');
 
-/***
-* @description Initializes the test context.
-***/
-    @testSetup
-    static void testSetup() {
-        System.debug('testSetup: START');
+		System.debug('testSetup: END');
+	}
 
-        System.debug('testSetup: END');
-    }
+	/***
+	* @description Tests the "getFieldSetDescs" and implicitly the "getFieldSetDesc" methods.
+	***/
+	@isTest
+	static void testGetFieldSetDescs() {
+		System.debug('testGetFieldSetDescs: START');
 
-/***
-* @description Tests the "getFieldSetDescs" and implicitly the "getFieldSetDesc" methods.
-***/    
-    static TestMethod void testGetFieldSetDescs() {
-        System.debug('testGetFieldSetDescs: START'); 
+		ApexClass ac = [SELECT NameSpacePrefix FROM ApexClass
+						WHERE Name LIKE 'sfpegGetFieldSet_CTL_TST'];
+		System.debug('testGetFieldSetDescs: NameSpace extracted' + ac);
+		String nsRoot = (ac.NameSpacePrefix == null ? '' : ac.NameSpacePrefix + '__');
+		String FieldSetName =  nsRoot + 'sfpegTest__c.' + nsRoot + 'TestFS';
+		System.debug('testGetFieldSetDescs: FieldSetName init' + FieldSetName);
+		String FieldSetNameKO =  nsRoot + 'sfpegTest__c.DUMMY';
 
-        ApexClass ac = [SELECT NameSpacePrefix FROM ApexClass
-                        WHERE Name LIKE 'sfpegGetFieldSet_CTL_TST'];
-        System.debug('testGetFieldSetDescs: NameSpace extracted' + ac);
-        String nsRoot = (ac.NameSpacePrefix == null ? '' : ac.NameSpacePrefix + '__');
-        String FieldSetName =  nsRoot + 'sfpegTest__c.' + nsRoot + 'TestFS';
-        System.debug('testGetFieldSetDescs: FieldSetName init' + FieldSetName);
-        String FieldSetNameKO =  nsRoot + 'sfpegTest__c.DUMMY';
+		Test.startTest();
 
-        Test.startTest();
+		// Standard working case
+		try {
+			List<String> nameList = new List<String>();
+			nameList.add(FieldSetName);
+			sfpegGetFieldSet_CTL.getFieldSetDescs(nameList);
+			//sfpegConfiguration_CTL.getFieldSetDesc('Task.SFPEG_TSTFS');
+			System.debug('testGetFieldSetDesc: no exception raised');
+			System.assert(true);
+		}
+		catch (Exception e) {
+			System.debug('testGetFieldSetDesc: exception raised (check 1st required SFPEG_TSTFS fieldset on Task object) ' + e.getMessage());
+			System.assert(false);
+		}
 
-        // Standard working case
-        try {
-            List<String> nameList = new List<String>();
-            nameList.add(FieldSetName);
-            sfpegGetFieldSet_CTL.getFieldSetDescs(nameList);
-            //sfpegConfiguration_CTL.getFieldSetDesc('Task.SFPEG_TSTFS');
-            System.debug('testGetFieldSetDesc: no exception raised');
-            System.assert(true);
-        }
-        catch (Exception e) {
-            System.debug('testGetFieldSetDesc: exception raised (check 1st required SFPEG_TSTFS fieldset on Task object) ' + e.getMessage());
-            System.assert(false);
-        }
+		// Error cases
+		try {
+			List<String> nameList = new List<String>();
+			nameList.add(FieldSetNameKO);
+			sfpegGetFieldSet_CTL.getFieldSetDescs(nameList);
+			//sfpegConfiguration_CTL.getFieldSetDesc('Task.SFPEG_TSTFS');
+			System.debug('testGetFieldSetDesc: no exception raised');
+			System.assert(false);
+		}
+		catch (Exception e) {
+			System.debug('testGetFieldSetDesc: exception raised ' + e.getMessage());
+			System.assert(true);
+		}
 
-        // Error cases
-        try {
-            List<String> nameList = new List<String>();
-            nameList.add(FieldSetNameKO);
-            sfpegGetFieldSet_CTL.getFieldSetDescs(nameList);
-            //sfpegConfiguration_CTL.getFieldSetDesc('Task.SFPEG_TSTFS');
-            System.debug('testGetFieldSetDesc: no exception raised');
-            System.assert(false);
-        }
-        catch (Exception e) {
-            System.debug('testGetFieldSetDesc: exception raised ' + e.getMessage());
-            System.assert(true);
-        }
-        
-        try {
-            List<String> nameList = new List<String>();
-            nameList.add('Test.Test');
-            sfpegGetFieldSet_CTL.getFieldSetDescs(nameList);
-            System.debug('testGetFieldSetDesc: no exception raised for Test.Test');
-            System.assert(false);
-        }
-        catch (Exception e) {
-            System.debug('testGetFieldSetDesc: exception raised for Test.Test' + e.getMessage());
-            System.assert(true);
-        }
+		try {
+			List<String> nameList = new List<String>();
+			nameList.add('Test.Test');
+			sfpegGetFieldSet_CTL.getFieldSetDescs(nameList);
+			System.debug('testGetFieldSetDesc: no exception raised for Test.Test');
+			System.assert(false);
+		}
+		catch (Exception e) {
+			System.debug('testGetFieldSetDesc: exception raised for Test.Test' + e.getMessage());
+			System.assert(true);
+		}
 
-        try {
-            List<String> nameList = new List<String>();
-            nameList.add('Test');
-            sfpegGetFieldSet_CTL.getFieldSetDescs(nameList);
-            System.debug('testGetFieldSetDesc: no exception raised for Test');
-            System.assert(false);
-        }
-        catch (Exception e) {
-            System.debug('testGetFieldSetDesc: exception raised for Test' + e.getMessage());
-            System.assert(true);
-        }
-        
-        Test.stopTest();
-        System.debug('testGetFieldSetDesc: END');
-    }
+		try {
+			List<String> nameList = new List<String>();
+			nameList.add('Test');
+			sfpegGetFieldSet_CTL.getFieldSetDescs(nameList);
+			System.debug('testGetFieldSetDesc: no exception raised for Test');
+			System.assert(false);
+		}
+		catch (Exception e) {
+			System.debug('testGetFieldSetDesc: exception raised for Test' + e.getMessage());
+			System.assert(true);
+		}
 
+		Test.stopTest();
+		System.debug('testGetFieldSetDesc: END');
+	}
 }

--- a/force-app/main/default/classes/sfpegGetFieldsetData_CTL.cls
+++ b/force-app/main/default/classes/sfpegGetFieldsetData_CTL.cls
@@ -30,17 +30,17 @@
 
 public with sharing class sfpegGetFieldsetData_CTL {
 
-/***
-* @description	Invocable method to easily fetch data corresponding to a given
-*               fieldset for a series of records based on their IDs.
-* @param		dataRequests	List of 'DataRequest' records containing the
-*                               records for which data should be fetched and the FieldSet
-*                               name (as 'Object.Fieldset', i.e. Object API & FS Developer
-*                               names). Each record should have an ID !
-* @return		List<List<SObject>>		List of matching records (of same sobject type with
-*                                       proper authorized fieldset fields returned).
-* @exception   	dmlExceptions in case of processing issue.
-***/
+	/***
+	* @description	Invocable method to easily fetch data corresponding to a given
+	*               fieldset for a series of records based on their IDs.
+	* @param		dataRequests	List of 'DataRequest' records containing the
+	*                               records for which data should be fetched and the FieldSet
+	*                               name (as 'Object.Fieldset', i.e. Object API & FS Developer
+	*                               names). Each record should have an ID !
+	* @return		List<List<SObject>>		List of matching records (of same sobject type with
+	*                                       proper authorized fieldset fields returned).
+	* @exception   	dmlExceptions in case of processing issue.
+	***/
 	@InvocableMethod(label='Get Records Data' description='Get data of a given fieldset for a list of records.' category='SF PEG')
 	public static List<List<SObject>> getData(List<DataRequest> dataRequests) {
 		System.debug('getData: START');
@@ -116,10 +116,10 @@ public with sharing class sfpegGetFieldsetData_CTL {
 		return resultList;
 	}
 
-/***
-* @description	Subclass required to pass input parameters into the 'getData' invocable action
-*               (especially to provide the fieldset name).
-***/
+	/***
+	* @description	Subclass required to pass input parameters into the 'getData' invocable action
+	*               (especially to provide the fieldset name).
+	***/
 	public class DataRequest {
 		@InvocableVariable(label='Records to Match' description='Records to match' required=true)
 		public List<SObject> records;

--- a/force-app/main/default/classes/sfpegGetFieldsetData_CTL.cls
+++ b/force-app/main/default/classes/sfpegGetFieldsetData_CTL.cls
@@ -27,7 +27,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 ***/
-
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class sfpegGetFieldsetData_CTL {
 
 	/***
@@ -94,7 +94,7 @@ public with sharing class sfpegGetFieldsetData_CTL {
 						+ ' WHERE ID in (\'' + String.join(new List<String>(recordIDs),'\',\'') + '\')';
 		System.debug('getData: soqlQuery init ' + soqlQuery);
 
-		Map<ID,SObject> resultMap = new Map<ID,SObject>(database.query(soqlQuery));//NOPMD safe params
+		Map<ID,SObject> resultMap = new Map<ID,SObject>(Database.query(soqlQuery));//NOPMD safe params
 		System.debug('getData: data fetched init ' + resultMap);
 
 		// format record result list
@@ -106,7 +106,7 @@ public with sharing class sfpegGetFieldsetData_CTL {
 			resultList.add(newData);
 			for (SObject iterRcd : iter.records) {
 				System.debug('getData: processing record ' + iterRcd);
-				Sobject iterData = resultMap.get(iterRcd.Id);
+				SObject iterData = resultMap.get(iterRcd.Id);
 				System.debug('getData: iter data fetcched ' + iterData);
 				newData.add(iterData);
 			}

--- a/force-app/main/default/classes/sfpegGetFieldsetData_CTL.cls
+++ b/force-app/main/default/classes/sfpegGetFieldsetData_CTL.cls
@@ -4,21 +4,21 @@
 * @description Flow controller class to check duplicates of a new record from a Flow.
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2020 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,100 +33,99 @@ public with sharing class sfpegGetFieldsetData_CTL {
 /***
 * @description	Invocable method to easily fetch data corresponding to a given
 *               fieldset for a series of records based on their IDs.
-* @param		dataRequests	List of 'DataRequest' records containing the 
+* @param		dataRequests	List of 'DataRequest' records containing the
 *                               records for which data should be fetched and the FieldSet
 *                               name (as 'Object.Fieldset', i.e. Object API & FS Developer
 *                               names). Each record should have an ID !
 * @return		List<List<SObject>>		List of matching records (of same sobject type with
 *                                       proper authorized fieldset fields returned).
 * @exception   	dmlExceptions in case of processing issue.
-***/    
-    @InvocableMethod(label='Get Records Data' description='Get data of a given fieldset for a list of records.' category='SF PEG')
+***/
+	@InvocableMethod(label='Get Records Data' description='Get data of a given fieldset for a list of records.' category='SF PEG')
 	public static List<List<SObject>> getData(List<DataRequest> dataRequests) {
 		System.debug('getData: START');
-		//System.debug('getData: newRecords received ' + newRecords);
-        
-        if ((dataRequests == null) || (dataRequests.size() == 0)) {
+
+		if ((dataRequests == null) || (dataRequests.size() == 0)) {
 			System.debug('getData: END KO / missing input dataRequests');
-            throw new dmlException('Missing input');
-        }
-        
-        String fieldsetName =  dataRequests[0].fieldset;
-		System.debug('getData: fieldsetName extracted ' + fieldsetName);        
-        if (String.isBlank(fieldsetName)) {
-            System.debug('getData: END KO / missing fieldSet Name ');
-            throw new dmlException('Missing fieldset name');
-        }
-      
-        // init record ID list
-        Set<String> recordIDs = new Set<String>();
-        for (DataRequest iter : dataRequests) {
+			throw new dmlException('Missing input');
+		}
+
+		String fieldsetName =  dataRequests[0].fieldset;
+		System.debug('getData: fieldsetName extracted ' + fieldsetName);
+		if (String.isBlank(fieldsetName)) {
+			System.debug('getData: END KO / missing fieldSet Name ');
+			throw new dmlException('Missing fieldset name');
+		}
+
+		// init record ID list
+		Set<String> recordIDs = new Set<String>();
+		for (DataRequest iter : dataRequests) {
 			System.debug('getData: registering iter ' + iter);
-            for (SObject iterRcd : iter.records) {
+			for (SObject iterRcd : iter.records) {
 				System.debug('getData: registering record ' + iterRcd);
-            	recordIDs.add(iterRcd.Id);
-            }
-        }                                
+				recordIDs.add(iterRcd.Id);
+			}
+		}
 		System.debug('getData: recordIDs extracted ' + recordIDs);
-        
-        // init field api name list
-        Map<String,Object> fieldSetDesc =   sfpegGetFieldSet_CTL.getFieldSetDesc(fieldsetName);
-        System.debug('getData: fieldSetDesc fetched ' + fieldSetDesc);
-        List<Map<String,Object>> fieldDescs = (List<Map<String,Object>>) (fieldSetDesc.get('fields'));
-        System.debug('getData: fieldDescs extracted ' + fieldDescs);
-        Set<String> fieldSet = new Set<String>();
-        if (fieldDescs != null) {
-            System.debug('getData: adding fields from fieldSet');
-            for (Map<String,Object> iterField : fieldDescs) {
-                System.debug('getData: processing iterField ' + iterField);
-                fieldSet.add((String)(iterField.get('name')));
-            }
-            System.debug('getData: set of field names init ' + fieldSet);
-        }
-        if (!String.isBlank(dataRequests[0].fieldNames)) {
+
+		// init field api name list
+		Map<String,Object> fieldSetDesc =   sfpegGetFieldSet_CTL.getFieldSetDesc(fieldsetName);
+		System.debug('getData: fieldSetDesc fetched ' + fieldSetDesc);
+		List<Map<String,Object>> fieldDescs = (List<Map<String,Object>>) (fieldSetDesc.get('fields'));
+		System.debug('getData: fieldDescs extracted ' + fieldDescs);
+		Set<String> fieldSet = new Set<String>();
+		if (fieldDescs != null) {
+			System.debug('getData: adding fields from fieldSet');
+			for (Map<String,Object> iterField : fieldDescs) {
+				System.debug('getData: processing iterField ' + iterField);
+				fieldSet.add((String)(iterField.get('name')));
+			}
+			System.debug('getData: set of field names init ' + fieldSet);
+		}
+		if (!String.isBlank(dataRequests[0].fieldNames)) {
 			System.debug('getData: adding special fields ' + dataRequests[0].fieldNames);
-            fieldSet.addAll(dataRequests[0].fieldNames.split(','));            
-        }
+			fieldSet.addAll(dataRequests[0].fieldNames.split(','));
+		}
 		System.debug('getData: set of field names finalised ' + fieldSet);
-        
-        // init and execute SOQL query
-        String soqlQuery = 'SELECT ' + String.join(new list<String>(fieldSet),',')
-            			+ ' FROM ' + fieldsetName.left(fieldsetName.indexOf('.'))
-            			+ ' WHERE ID in (\'' + String.join(new List<String>(recordIDs),'\',\'') + '\')';
-		System.debug('getData: soqlQuery init ' + soqlQuery);    
-        
-        Map<ID,SObject> resultMap = new Map<ID,SObject>(database.query(soqlQuery));
-		System.debug('getData: data fetched init ' + resultMap);    
-        
-        // format record result list
-        List<List<SObject>> resultList = new List<List<SObject>>();
-        for (DataRequest iter : dataRequests) {
+
+		// init and execute SOQL query
+		String soqlQuery = 'SELECT ' + String.join(new list<String>(fieldSet),',')
+						+ ' FROM ' + fieldsetName.left(fieldsetName.indexOf('.'))
+						+ ' WHERE ID in (\'' + String.join(new List<String>(recordIDs),'\',\'') + '\')';
+		System.debug('getData: soqlQuery init ' + soqlQuery);
+
+		Map<ID,SObject> resultMap = new Map<ID,SObject>(database.query(soqlQuery));//NOPMD safe params
+		System.debug('getData: data fetched init ' + resultMap);
+
+		// format record result list
+		List<List<SObject>> resultList = new List<List<SObject>>();
+		for (DataRequest iter : dataRequests) {
 			System.debug('getData: finalising iter ' + iter);
-            
-            List<SObject> newData = new List<SObject>();    
-            resultList.add(newData);
-            for (SObject iterRcd : iter.records) {
-                System.debug('getData: processing record ' + iterRcd);
-                Sobject iterData = resultMap.get(iterRcd.Id);
-                System.debug('getData: iter data fetcched ' + iterData);
-            	newData.add(iterData);                
-            }
-        }
-        
-		System.debug('getData: END OK with ' + resultList);        
-        return resultList;
-	}   
-    
+
+			List<SObject> newData = new List<SObject>();
+			resultList.add(newData);
+			for (SObject iterRcd : iter.records) {
+				System.debug('getData: processing record ' + iterRcd);
+				Sobject iterData = resultMap.get(iterRcd.Id);
+				System.debug('getData: iter data fetcched ' + iterData);
+				newData.add(iterData);
+			}
+		}
+
+		System.debug('getData: END OK with ' + resultList);
+		return resultList;
+	}
+
 /***
 * @description	Subclass required to pass input parameters into the 'getData' invocable action
 *               (especially to provide the fieldset name).
 ***/
-    public class DataRequest {
-  		@InvocableVariable(label='Records to Match' description='Records to match' required=true)
-  		public List<SObject> records;
-        @InvocableVariable(label='Fieldset' description='Fieldset to return' required=true)
-  		public String fieldset;
-        @InvocableVariable(label='Fields' description='Individual fields to return' required=false)
-  		public String fieldNames;
-  	}  
+	public class DataRequest {
+		@InvocableVariable(label='Records to Match' description='Records to match' required=true)
+		public List<SObject> records;
+		@InvocableVariable(label='Fieldset' description='Fieldset to return' required=true)
+		public String fieldset;
+		@InvocableVariable(label='Fields' description='Individual fields to return' required=false)
+		public String fieldNames;
+  	}
 }

--- a/force-app/main/default/classes/sfpegGetFieldsetData_CTL_TST.cls
+++ b/force-app/main/default/classes/sfpegGetFieldsetData_CTL_TST.cls
@@ -5,21 +5,21 @@
 * @see         sfpegGetFieldsetData_CTL
 *
 * Legal Notice
-* 
+*
 * MIT License
-* 
+*
 * Copyright (c) 2020 pegros
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,81 +30,82 @@
 ***/
 
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions')
 public class sfpegGetFieldsetData_CTL_TST {
-    
-/***
-* @description Initializes the test context.
-***/
-    @testSetup
-    static void testSetup() {
-        System.debug('testSetup: START');
 
-        System.debug('testSetup: END');
-    }
+	/***
+	* @description Initializes the test context.
+	***/
+	@testSetup
+	static void testSetup() {
+		System.debug('testSetup: START');
 
+		System.debug('testSetup: END');
+	}
 
-/***
-* @description Tests the "getData" method.
-***/
-    
-    static TestMethod void testGetData() {
-        System.debug('testGetData: START'); 
+	/***
+	* @description Tests the "getData" method.
+	***/
 
-        ApexClass ac = [SELECT NameSpacePrefix FROM ApexClass
-                        WHERE Name LIKE 'sfpegGetFieldSet_CTL_TST'];
-        System.debug('testGetData: NameSpace extracted' + ac);
-        String nsRoot = (ac.NameSpacePrefix == null ? '' : ac.NameSpacePrefix + '__');
-        String FieldSetName =  nsRoot + 'sfpegTest__c.' + nsRoot + 'TestFS';
-        System.debug('testGetData: FieldSetName init' + FieldSetName);
+	@isTest
+	static void testGetData() {
+		System.debug('testGetData: START');
 
-        Test.startTest();
-        
-        sfpegTest__c newTest = new sfpegTest__c(Name = 'Test1',Data__c = 'Data1');
-        insert newTest;
-        sfpegGetFieldsetData_CTL.DataRequest newReq = new sfpegGetFieldsetData_CTL.DataRequest();
-        newReq.records = new List<SObject>();
-        newReq.records.add(newTest);
-        newReq.fieldset = FieldSetName;
-        newReq.fieldNames = 'CreatedById';
-        List<sfpegGetFieldsetData_CTL.DataRequest> requests = new List<sfpegGetFieldsetData_CTL.DataRequest>();
-        requests.add(newReq);
-        System.debug('testGetData: test data ready ' + requests); 
+		ApexClass ac = [SELECT NameSpacePrefix FROM ApexClass
+						WHERE Name LIKE 'sfpegGetFieldSet_CTL_TST'];
+		System.debug('testGetData: NameSpace extracted' + ac);
+		String nsRoot = (ac.NameSpacePrefix == null ? '' : ac.NameSpacePrefix + '__');
+		String FieldSetName =  nsRoot + 'sfpegTest__c.' + nsRoot + 'TestFS';
+		System.debug('testGetData: FieldSetName init' + FieldSetName);
 
-        List<List<SObject>>  results;
-        try {
-	        results = sfpegGetFieldsetData_CTL.getData(null);
-            System.debug('testGetData: null request fetched ' + results); 
-            system.assert(false);
-        }
-        catch (Exception e) {
-            System.debug('testGetData: null request error / ' + e.getMessage());  
-            system.assert(true);           
-        }
+		Test.startTest();
 
-        try {
-	        results = sfpegGetFieldsetData_CTL.getData(requests);
-            System.debug('testGetData: good request fetched ' + results); 
-            system.assertEquals(results.size(),1);
-            system.assertEquals(results[0].size(),1);
-        }
-        catch (Exception e) {
-            System.debug('testGetData: good request error / ' + e.getMessage());  
-            system.assert(false);           
-        }
+		sfpegTest__c newTest = new sfpegTest__c(Name = 'Test1',Data__c = 'Data1');
+		insert newTest;
+		sfpegGetFieldsetData_CTL.DataRequest newReq = new sfpegGetFieldsetData_CTL.DataRequest();
+		newReq.records = new List<SObject>();
+		newReq.records.add(newTest);
+		newReq.fieldset = FieldSetName;
+		newReq.fieldNames = 'CreatedById';
+		List<sfpegGetFieldsetData_CTL.DataRequest> requests = new List<sfpegGetFieldsetData_CTL.DataRequest>();
+		requests.add(newReq);
+		System.debug('testGetData: test data ready ' + requests);
 
-        newReq.fieldset = 'dummy';
-        try {
-	        results = sfpegGetFieldsetData_CTL.getData(requests);
-            System.debug('testGetData: dummy FS request fetched ' + results); 
-            system.assert(false);
-        }
-        catch (Exception e) {
-            System.debug('testGetData: dummy FS request error / ' + e.getMessage());  
-            system.assert(true);           
-        }
+		List<List<SObject>>  results;
+		try {
+			results = sfpegGetFieldsetData_CTL.getData(null);
+			System.debug('testGetData: null request fetched ' + results);
+			System.assert(false);
+		}
+		catch (Exception e) {
+			System.debug('testGetData: null request error / ' + e.getMessage());
+			System.assert(true);
+		}
 
-        Test.stopTest();
-        System.debug('testGetData: END');
-    }
+		try {
+			results = sfpegGetFieldsetData_CTL.getData(requests);
+			System.debug('testGetData: good request fetched ' + results);
+			System.assertEquals(results.size(),1);
+			System.assertEquals(results[0].size(),1);
+		}
+		catch (Exception e) {
+			System.debug('testGetData: good request error / ' + e.getMessage());
+			System.assert(false);
+		}
+
+		newReq.fieldset = 'dummy';
+		try {
+			results = sfpegGetFieldsetData_CTL.getData(requests);
+			System.debug('testGetData: dummy FS request fetched ' + results);
+			System.assert(false);
+		}
+		catch (Exception e) {
+			System.debug('testGetData: dummy FS request error / ' + e.getMessage());
+			System.assert(true);
+		}
+
+		Test.stopTest();
+		System.debug('testGetData: END');
+	}
 
 }

--- a/force-app/main/default/duplicateRules/sfpegTest__c.sfpegTest.duplicateRule-meta.xml
+++ b/force-app/main/default/duplicateRules/sfpegTest__c.sfpegTest.duplicateRule-meta.xml
@@ -10,7 +10,7 @@
         <matchingRule>sfpegTestMatchingRule</matchingRule>
         <objectMapping xsi:nil="true"/>
     </duplicateRuleMatchRules>
-    <isActive>false</isActive>
+    <isActive>true</isActive>
     <masterLabel>sfpegTest</masterLabel>
     <operationsOnInsert>Alert</operationsOnInsert>
     <operationsOnUpdate>Alert</operationsOnUpdate>

--- a/force-app/main/default/duplicateRules/sfpegTest__c.sfpegTest.duplicateRule-meta.xml
+++ b/force-app/main/default/duplicateRules/sfpegTest__c.sfpegTest.duplicateRule-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DuplicateRule xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <actionOnInsert>Allow</actionOnInsert>
+    <actionOnUpdate>Allow</actionOnUpdate>
+    <alertText>Use one of these records?</alertText>
+    <description>Used to test sfpegGetDuplicates_CTL class</description>
+    <duplicateRuleFilter xsi:nil="true"/>
+    <duplicateRuleMatchRules>
+        <matchRuleSObjectType>sfpegTest__c</matchRuleSObjectType>
+        <matchingRule>sfpegTestMatchingRule</matchingRule>
+        <objectMapping xsi:nil="true"/>
+    </duplicateRuleMatchRules>
+    <isActive>false</isActive>
+    <masterLabel>sfpegTest</masterLabel>
+    <operationsOnInsert>Alert</operationsOnInsert>
+    <operationsOnUpdate>Alert</operationsOnUpdate>
+    <securityOption>EnforceSharingRules</securityOption>
+    <sortOrder>1</sortOrder>
+</DuplicateRule>

--- a/force-app/main/default/matchingRules/sfpegTest__c.matchingRule-meta.xml
+++ b/force-app/main/default/matchingRules/sfpegTest__c.matchingRule-meta.xml
@@ -6,11 +6,6 @@
         <label>sfpegTest Matching Rule</label>
         <matchingRuleItems>
             <blankValueBehavior>NullNotAllowed</blankValueBehavior>
-            <fieldName>Data__c</fieldName>
-            <matchingMethod>Exact</matchingMethod>
-        </matchingRuleItems>
-        <matchingRuleItems>
-            <blankValueBehavior>NullNotAllowed</blankValueBehavior>
             <fieldName>Name</fieldName>
             <matchingMethod>Exact</matchingMethod>
         </matchingRuleItems>

--- a/force-app/main/default/matchingRules/sfpegTest__c.matchingRule-meta.xml
+++ b/force-app/main/default/matchingRules/sfpegTest__c.matchingRule-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MatchingRules xmlns="http://soap.sforce.com/2006/04/metadata">
+    <matchingRules>
+        <fullName>sfpegTestMatchingRule</fullName>
+        <description>Used to test sfpegGetDuplicates_CTL class</description>
+        <label>sfpegTest Matching Rule</label>
+        <matchingRuleItems>
+            <blankValueBehavior>NullNotAllowed</blankValueBehavior>
+            <fieldName>Data__c</fieldName>
+            <matchingMethod>Exact</matchingMethod>
+        </matchingRuleItems>
+        <matchingRuleItems>
+            <blankValueBehavior>NullNotAllowed</blankValueBehavior>
+            <fieldName>Name</fieldName>
+            <matchingMethod>Exact</matchingMethod>
+        </matchingRuleItems>
+        <ruleStatus>Inactive</ruleStatus>
+    </matchingRules>
+</MatchingRules>

--- a/force-app/main/default/matchingRules/sfpegTest__c.matchingRule-meta.xml
+++ b/force-app/main/default/matchingRules/sfpegTest__c.matchingRule-meta.xml
@@ -9,6 +9,6 @@
             <fieldName>Name</fieldName>
             <matchingMethod>Exact</matchingMethod>
         </matchingRuleItems>
-        <ruleStatus>Inactive</ruleStatus>
+        <ruleStatus>Active</ruleStatus>
     </matchingRules>
 </MatchingRules>

--- a/force-app/main/default/objects/sfpegTest__c/sfpegTest__c.object-meta.xml
+++ b/force-app/main/default/objects/sfpegTest__c/sfpegTest__c.object-meta.xml
@@ -153,14 +153,13 @@
     <enableSearch>false</enableSearch>
     <enableSharing>false</enableSharing>
     <enableStreamingApi>false</enableStreamingApi>
-    <gender>Feminine</gender>
     <label>sfpegTest</label>
     <nameField>
         <label>Name</label>
         <type>Text</type>
     </nameField>
     <pluralLabel>sfpegTests</pluralLabel>
-    <searchLayouts/>
+    <searchLayouts />
     <sharingModel>ReadWrite</sharingModel>
     <visibility>Public</visibility>
 </CustomObject>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -7,5 +7,5 @@
   ],
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "50.0"
+  "sourceApiVersion": "55.0"
 }


### PR DESCRIPTION
Implement Apex PMD rules
Refactor sfpegGetDuplicates_CTL class to avoid dummy method by adding duplicate rule and matching rule on sfpegTest__c object