### PR TITLE
Remove gender from object definition

### DIFF
--- a/force-app/main/default/objects/sfpegTest__c/sfpegTest__c.object-meta.xml
+++ b/force-app/main/default/objects/sfpegTest__c/sfpegTest__c.object-meta.xml
@@ -153,7 +153,6 @@
     <enableSearch>false</enableSearch>
     <enableSharing>false</enableSharing>
     <enableStreamingApi>false</enableStreamingApi>
-    <gender>Feminine</gender>
     <label>sfpegTest</label>
     <nameField>
         <label>Name</label>


### PR DESCRIPTION
Hi @pegros,

Another instance of gender in the object definition.  

Here is a bit of background on the issue...  https://developer.salesforce.com/forums/?id=906F00000008uyaIAA