### PR TITLE
Resize the tiles/fields when the CMP is rendered on non-desktop(PC) devices

### DIFF
--- a/force-app/main/default/lwc/sfpegRecordEditFlw/sfpegRecordEditFlw.js
+++ b/force-app/main/default/lwc/sfpegRecordEditFlw/sfpegRecordEditFlw.js
@@ -45,6 +45,7 @@ export default class SfpegRecordEditFlw extends LightningElement {
     @api cardTitle;             // Title of the wrapping Card
     @api cardIcon;              // Icon of the wrapping Card
     @api tileSize = 4;          // tile size (in tiles mode)
+    @api tileSizeMobile = 12;   // tile size mobile (in tiles mode)
     @api cardClass;             // CSS Classes for the wrapping card div
     @api fieldSetName = null;   // fieldset for additional info in tiles
     @api mainRecord = {};       // input record
@@ -64,7 +65,10 @@ export default class SfpegRecordEditFlw extends LightningElement {
     fieldSetDesc = [];          //fieldset desc received
     objectName = null;          //object API name
     objectRecordType = null;    //Record Type
-    @track lastModif = null;         
+    @track lastModif = null;          
+
+    // Checks if current device is not a desktop device. (Can be an android phone/IOS/tablet etc)
+    isNonDesktopDevice = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
 
     //Display mode getters
     get displayButtons() {
@@ -134,6 +138,15 @@ export default class SfpegRecordEditFlw extends LightningElement {
 
         this.objectRecordType = this.mainRecord['recordTypeId'] || this.mainRecord['RecordTypeId'];
         if (this.isDebug) console.log('connectedCallback: objectRecordType init', JSON.stringify(this.objectRecordType));    
+
+        // Check if device is not desktop (can be android/ios/tablet etc)
+        if(this.isNonDesktopDevice){
+            this.tileSize = this.tileSizeMobile; // replace tilesize value by tileSizeMobile value
+            if (this.isDebug) console.log('connectedCallback device is not desktop, tile size is: ', this.tileSize); 
+        }
+        else{
+            if (this.isDebug) console.log('connectedCallback device is desktop, tile size is: ', this.tileSize);            
+        }
 
         if (this.isDebug) console.log('connectedCallback: END');        
     }

--- a/force-app/main/default/lwc/sfpegRecordEditFlw/sfpegRecordEditFlw.js-meta.xml
+++ b/force-app/main/default/lwc/sfpegRecordEditFlw/sfpegRecordEditFlw.js-meta.xml
@@ -29,6 +29,13 @@
                         type="Integer"
                         role="inputOnly"
                         description="Field display size (X on 12)."/>
+
+            <property   name="tileSizeMobile"
+                        label="Field Size (Mobile)"
+                        type="Integer"
+                        role="inputOnly"
+                        default="12"
+                        description="Field display size (X on 12) for devices other than desktop (Mobile, tablet, etc)."/>
                                     
             <property   name="fieldSetName"
                         label="Detail FieldSet"


### PR DESCRIPTION
Hello @pegros 

If possible to render the fields display and cardTitle of the components on devices such as Mobile/Tablets and make them responsive.

![image](https://github.com/pegros/PEG_FLW/assets/35396212/34744aec-bbe9-42b2-8e2b-b8917c38e522)

![image](https://github.com/pegros/PEG_FLW/assets/35396212/b792383b-b286-423f-9357-0fb4ff3f290c)

Thanks.