### PR TITLE
Update sfpegRecordEditFlw.js For Handling Null values

### DIFF
--- a/force-app/main/default/lwc/sfpegRecordEditFlw/sfpegRecordEditFlw.js
+++ b/force-app/main/default/lwc/sfpegRecordEditFlw/sfpegRecordEditFlw.js
@@ -161,7 +161,7 @@ export default class SfpegRecordEditFlw extends LightningElement {
         this.lastModif = fieldName + ' from ' + oldValue + ' to ' + newValue;
         if (this.isDebug) console.log('handleChange: lastModif tracked ', this.lastModif);
 
-        this.newRecord[fieldName] = newValue;
+        this.newRecord[fieldName] = newValue?newValue:null;
         if (this.isDebug) console.log('handleChange: newRecord updated', this.newRecord[fieldName]);
         if (this.isDebug) console.log('handleChange: newRecord updated', JSON.stringify(this.newRecord));
 


### PR DESCRIPTION
for fixing bug - if we try to remove any value from the field then it doesnt include that field in new record list.


Because the value returned is undefined so it doesnt include that field where value is being removed. So if user tries to remove lookup then it will not allow that.

Solution: If its undefined then override it with null this way it will be automatically included in the newRecord List which in turn be returned to output then that can be updated later.